### PR TITLE
Fixed bug when path has white space characters.

### DIFF
--- a/bin/Install-Remove-Service.bat
+++ b/bin/Install-Remove-Service.bat
@@ -72,7 +72,7 @@ goto end
 echo Installing service '%SERVICE_NAME%' ...
 echo.
 
-set EXECUTE_STRING= %EXECUTABLE% //IS//%SERVICE_NAME%  --Startup %CG_STARTUP_TYPE%  --StartClass %CG_START_CLASS% --StopClass %CG_STOP_CLASS%
+set EXECUTE_STRING= "%EXECUTABLE%" //IS//%SERVICE_NAME%  --Startup %CG_STARTUP_TYPE%  --StartClass %CG_START_CLASS% --StopClass %CG_STOP_CLASS%
 call:executeAndPrint %EXECUTE_STRING%
 
 set EXECUTE_STRING= "%EXECUTABLE%" //US//%SERVICE_NAME% --StartMode jvm --StopMode jvm --Jvm %CG_PATH_TO_JVM%


### PR DESCRIPTION
Added double quotations around %EXECUTABLE% so that paths with white space in them are properly handled, as they are in the rest of this script.
